### PR TITLE
Logging Service

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -102,7 +102,7 @@ IncludeCategories:
     Priority:        1
     CaseSensitive:   true
     # Yasic dedendencies
-  - Regex:           '("(SDL*|glm|entt|nlohmann|stb))'
+  - Regex:           '("(SDL*|glm|entt|nlohmann|stb|spdlog|fmt))'
     Priority:        2
     CaseSensitive:   true
     # C++ standard library headers.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >
   -cppcoreguidelines-pro-type-union-access,
   -darwin-*,
   -fuchsia-*,
+  -readability-avoid-const-params-in-decls,
   -linuxkernel-*,
   -llvm-*,
   -llvmlibc-*,
@@ -20,6 +21,7 @@ Checks: >
   -mpi-*,
   -objc-*,
   -openmp-*,
+  -performance-enum-size,
   -zircon-*,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
@@ -72,7 +74,7 @@ CheckOptions:
   readability-identifier-naming.MethodCase: lower_case
   readability-identifier-naming.NamespaceCase: lower_case
   readability-identifier-naming.ParameterCase: lower_case
-  readability-identifier-naming.ParameterPackCase: CamelCase
+  readability-identifier-naming.ParameterPackCase: lower_case
   readability-identifier-naming.PointerParameterCase: lower_case
   readability-identifier-naming.PrivateMemberCase: lower_case
   readability-identifier-naming.PrivateMemberPrefix: m_

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -6,7 +6,7 @@ include (FetchContent)
 
 FetchContent_Declare (
     _doxygen_theme
-    URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v2.2.1.zip
+    URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v2.3.4.zip
 )
 FetchContent_MakeAvailable (_doxygen_theme)
 
@@ -33,7 +33,7 @@ set (DOXYGEN_HTML_EXTRA_STYLESHEET
 
 doxygen_add_docs (
     docs
-    ${PROJECT_SOURCE_DIR}/libs
+    ${PROJECT_SOURCE_DIR}/yasic
     ${PROJECT_SOURCE_DIR}/README.md
     ${PROJECT_SOURCE_DIR}/LICENSE.md
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,4 +6,7 @@ if (YASIC_ENABLE_TESTING)
 	add_subdirectory (googletest)
 endif ()
 
+add_subdirectory (fmt)
+add_subdirectory (spdlog)
+
 add_subdirectory (sdl)

--- a/external/fmt/CMakeLists.txt
+++ b/external/fmt/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+# SPDX-License-Identifier: MIT
+
+FetchContent_Declare (
+	fmt
+
+	URL https://github.com/fmtlib/fmt/archive/refs/tags/11.2.0.zip
+
+	OVERRIDE_FIND_PACKAGE
+	DOWNLOAD_NO_PROGRESS TRUE
+	SYSTEM
+)
+
+FetchContent_MakeAvailable (fmt)

--- a/external/spdlog/CMakeLists.txt
+++ b/external/spdlog/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+# SPDX-License-Identifier: MIT
+
+FetchContent_Declare (
+	spdlog
+
+	URL https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.zip
+
+	OVERRIDE_FIND_PACKAGE
+	DOWNLOAD_NO_PROGRESS TRUE
+	SYSTEM
+)
+
+set (SPDLOG_FMT_EXTERNAL ON CACHE BOOL "Use fmt from external source")
+
+FetchContent_MakeAvailable (spdlog)

--- a/tools/cmake/toolchains/clang-cl.toolchain.cmake
+++ b/tools/cmake/toolchains/clang-cl.toolchain.cmake
@@ -10,4 +10,8 @@ set (
 	-Wno-c++20-compat
 	-Wno-padded
 	-Wno-exit-time-destructors
+	-Wno-missing-prototypes
+	-Wno-weak-vtables
+	-Wno-global-constructors
+	-Wno-switch-default
 )

--- a/tools/cmake/toolchains/clang-cl.toolchain.cmake
+++ b/tools/cmake/toolchains/clang-cl.toolchain.cmake
@@ -14,4 +14,5 @@ set (
 	-Wno-weak-vtables
 	-Wno-global-constructors
 	-Wno-switch-default
+	-Wno-ctad-maybe-unsupported
 )

--- a/tools/cmake/toolchains/clang.toolchain.cmake
+++ b/tools/cmake/toolchains/clang.toolchain.cmake
@@ -14,4 +14,5 @@ set (
 	-Wno-weak-vtables
 	-Wno-global-constructors
 	-Wno-switch-default
+	-Wno-ctad-maybe-unsupported
 )

--- a/tools/cmake/toolchains/clang.toolchain.cmake
+++ b/tools/cmake/toolchains/clang.toolchain.cmake
@@ -13,4 +13,5 @@ set (
 	-Wno-missing-prototypes
 	-Wno-weak-vtables
 	-Wno-global-constructors
+	-Wno-switch-default
 )

--- a/yasic/CMakeLists.txt
+++ b/yasic/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries (
 
 	PUBLIC
 	Yasic::CompilerFlags
+	Yasic::Service
 	Yasic::Logging
 	SDL3::SDL3
 )

--- a/yasic/CMakeLists.txt
+++ b/yasic/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Copyright 2025 - David Brown <d.brown@bigdavedev.com>
 # SPDX-License-Identifier: MIT
 
+add_subdirectory (service)
+add_subdirectory (logging)
+
 add_executable (yasic)
+
 
 target_sources (
 	yasic
@@ -23,5 +27,6 @@ target_link_libraries (
 
 	PUBLIC
 	Yasic::CompilerFlags
+	Yasic::Logging
 	SDL3::SDL3
 )

--- a/yasic/logging/CMakeLists.txt
+++ b/yasic/logging/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+# SPDX-License-Identifier: MIT
+add_library (yasic_logging)
+add_library (Yasic::Logging ALIAS yasic_logging)
+
+target_sources (
+	yasic_logging
+
+	PUBLIC
+	FILE_SET yasic_logging_headers
+	TYPE HEADERS
+	BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+	FILES
+	include/yasic/logging/log_service.h
+	include/yasic/logging/null_log_service.h
+	include/yasic/logging/spdlog_service.h
+
+	PRIVATE
+	source/yasic/logging/spdlog_service.cpp
+)
+
+target_link_libraries (
+	yasic_logging
+
+	PUBLIC
+	Yasic::CompilerFlags
+	Yasic::Service
+
+	fmt::fmt
+	spdlog::spdlog
+)

--- a/yasic/logging/include/yasic/logging/log_service.h
+++ b/yasic/logging/include/yasic/logging/log_service.h
@@ -7,6 +7,7 @@
 #include "fmt/format.h"
 
 #include <string>
+#include <string_view>
 
 namespace yasic::logging
 {
@@ -25,7 +26,7 @@ class logging_service : public yasic::service::service_base
 public:
 	class context final
 	{
-		std::string m_name{};
+		std::string m_name;
 
 	public:
 		explicit context(std::string_view const name)

--- a/yasic/logging/include/yasic/logging/log_service.h
+++ b/yasic/logging/include/yasic/logging/log_service.h
@@ -4,9 +4,9 @@
 
 #include "yasic/service/service.h"
 
-#include <string>
-
 #include "fmt/format.h"
+
+#include <string>
 
 namespace yasic::logging
 {
@@ -28,12 +28,13 @@ public:
 		std::string m_name{};
 
 	public:
-		explicit context(std::string const& name)
-		    : m_name(name)
+		explicit context(std::string_view const name)
+		    : m_name{name}
 		{}
 
 		context() = delete;
 
+		[[nodiscard]]
 		std::string_view name() const
 		{
 			return m_name;
@@ -43,6 +44,7 @@ public:
 	/**
 	 * Log a message with the specified log level.
 	 *
+	 * @param ctx The logging context to use.
 	 * @param level The log level to use.
 	 * @param msg The formatted message to log.
 	 * @param args Any arguments for the formatted string.
@@ -58,9 +60,23 @@ public:
 		         fmt::format(std::move(msg), std::forward<Args>(args)...));
 	}
 
+	/**
+	 * Set the minimum log level for a specific context.
+	 *
+	 * @param ctx Context for which to set the log level.
+	 * @param log_level Level to set for the context.
+	 */
 	virtual void set_level(context const& ctx, log_level log_level) = 0;
 
-	virtual context create_context(std::string const& name) = 0;
+	/**
+	 * Create a new logging context with the specified name.
+	 *
+	 * In order to log messages, you must first create a context.
+	 *
+	 * @param name Name of the context to create.
+	 * @return A new logging context.
+	 */
+	virtual context create_context(std::string_view name) = 0;
 
 private:
 	virtual void log_impl(context const&     ctx,

--- a/yasic/logging/include/yasic/logging/log_service.h
+++ b/yasic/logging/include/yasic/logging/log_service.h
@@ -1,0 +1,47 @@
+// Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "yasic/service/service.h"
+
+#include <string>
+
+#include "fmt/format.h"
+
+namespace yasic::logging
+{
+enum class log_level
+{
+	trace,
+	debug,
+	info,
+	warn,
+	error,
+	fatal
+};
+
+class logging_service : public yasic::service::service_base
+{
+public:
+	/**
+	 * Log a message with the specified log level.
+	 *
+	 * @param level The log level to use.
+	 * @param msg The formatted message to log.
+	 * @param args Any arguments for the formatted string.
+	 */
+	template <typename... Args>
+	void log(log_level const               level,
+	         fmt::format_string<Args...>&& msg,
+	         Args&&... args)
+	{
+		log_impl(level, fmt::format(std::move(msg), std::forward<Args>(args)...));
+	}
+
+	virtual void set_level(log_level const log_level) = 0;
+
+private:
+	virtual void log_impl(log_level const level, std::string const& message) = 0;
+
+};
+} // namespace yasic::logging

--- a/yasic/logging/include/yasic/logging/log_service.h
+++ b/yasic/logging/include/yasic/logging/log_service.h
@@ -23,6 +23,23 @@ enum class log_level
 class logging_service : public yasic::service::service_base
 {
 public:
+	class context final
+	{
+		std::string m_name{};
+
+	public:
+		explicit context(std::string const& name)
+		    : m_name(name)
+		{}
+
+		context() = delete;
+
+		std::string_view name() const
+		{
+			return m_name;
+		}
+	};
+
 	/**
 	 * Log a message with the specified log level.
 	 *
@@ -31,17 +48,23 @@ public:
 	 * @param args Any arguments for the formatted string.
 	 */
 	template <typename... Args>
-	void log(log_level const               level,
+	void log(context const&                ctx,
+	         log_level const               level,
 	         fmt::format_string<Args...>&& msg,
 	         Args&&... args)
 	{
-		log_impl(level, fmt::format(std::move(msg), std::forward<Args>(args)...));
+		log_impl(ctx,
+		         level,
+		         fmt::format(std::move(msg), std::forward<Args>(args)...));
 	}
 
-	virtual void set_level(log_level const log_level) = 0;
+	virtual void set_level(context const& ctx, log_level log_level) = 0;
+
+	virtual context create_context(std::string const& name) = 0;
 
 private:
-	virtual void log_impl(log_level const level, std::string const& message) = 0;
-
+	virtual void log_impl(context const&     ctx,
+	                      log_level          level,
+	                      std::string const& message) = 0;
 };
 } // namespace yasic::logging

--- a/yasic/logging/include/yasic/logging/null_log_service.h
+++ b/yasic/logging/include/yasic/logging/null_log_service.h
@@ -1,0 +1,33 @@
+// Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "yasic/logging/log_service.h"
+#include "yasic/service/service.h"
+
+#include <string>
+
+namespace yasic::logging
+{
+/**
+ * Null logger service that does nothing.
+ *
+ * This service is used when no logging is required.
+ */
+class null_log_service : public yasic::service::service<logging_service>
+{
+public:
+	null_log_service() = default;
+
+	void set_level(log_level const /*log_level*/) override
+	{
+		// Do nothing
+	}
+
+private:
+	void log_impl(log_level const /*level*/, std::string const& /*message*/) override
+	{
+		// Do nothing
+	}
+};
+} // namespace yasic::logging

--- a/yasic/logging/include/yasic/logging/spdlog_service.h
+++ b/yasic/logging/include/yasic/logging/spdlog_service.h
@@ -1,0 +1,27 @@
+// Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "yasic/logging/log_service.h"
+#include "yasic/service/service.h"
+
+#include "spdlog/logger.h"
+
+#include <memory>
+#include <string>
+
+namespace yasic::logging
+{
+class spdlog_service : public yasic::service::service<logging_service>
+{
+public:
+	explicit spdlog_service(std::string const& context);
+
+	void set_level(log_level const log_level) override;
+
+private:
+	void log_impl(log_level const level, std::string const& message) override;
+
+	std::shared_ptr<spdlog::logger> m_logger;
+};
+} // namespace yasic::logging

--- a/yasic/logging/include/yasic/logging/spdlog_service.h
+++ b/yasic/logging/include/yasic/logging/spdlog_service.h
@@ -58,10 +58,10 @@ private:
 	{
 		using is_transparent = void;
 
-		std::size_t operator()(std::string_view const s) const
+		std::size_t operator()(std::string_view const string) const
 		{
 			constexpr std::hash<std::string_view> hasher{};
-			return hasher(s);
+			return hasher(string);
 		}
 	};
 

--- a/yasic/logging/include/yasic/logging/spdlog_service.h
+++ b/yasic/logging/include/yasic/logging/spdlog_service.h
@@ -5,10 +5,10 @@
 #include "yasic/logging/log_service.h"
 #include "yasic/service/service.h"
 
-#include "spdlog/logger.h"
-
 #include <memory>
 #include <string>
+
+#include "spdlog/logger.h"
 
 namespace yasic::logging
 {
@@ -17,10 +17,10 @@ class spdlog_service : public yasic::service::service<logging_service>
 public:
 	explicit spdlog_service(std::string const& context);
 
-	void set_level(log_level const log_level) override;
+	void set_level(log_level log_level) override;
 
 private:
-	void log_impl(log_level const level, std::string const& message) override;
+	void log_impl(log_level level, std::string const& message) override;
 
 	std::shared_ptr<spdlog::logger> m_logger;
 };

--- a/yasic/logging/include/yasic/logging/spdlog_service.h
+++ b/yasic/logging/include/yasic/logging/spdlog_service.h
@@ -32,22 +32,14 @@ public:
 	explicit spdlog_service(std::string_view log_file_name);
 
 	/**
-	 * Set the minimum log level for a specific context.
-	 *
-	 * @param ctx Context for which to set the log level.
-	 * @param log_level Level to set for the context.
+	 * @copydoc {yasic::logging::logging_service::set_level}
 	 */
 	void set_level(context const& ctx, log_level log_level) override;
 
 	/**
-	 * Create a new logging context with the specified name.
-	 *
-	 * In order to log messages, you must first create a context.
-	 *
-	 * @param name Name of the context to create.
-	 * @return A new logging context.
+	 * @copydoc{yasic::logging::logging_service::create_context}
 	 */
-	context create_context(std::string const& name) override;
+	context create_context(std::string_view name) override;
 
 	/**
 	 * Add a sink to the logging service.

--- a/yasic/logging/include/yasic/logging/spdlog_service.h
+++ b/yasic/logging/include/yasic/logging/spdlog_service.h
@@ -5,23 +5,80 @@
 #include "yasic/logging/log_service.h"
 #include "yasic/service/service.h"
 
+#include "spdlog/logger.h"
+#include "spdlog/sinks/base_sink.h"
+
 #include <memory>
 #include <string>
-
-#include "spdlog/logger.h"
+#include <unordered_map>
 
 namespace yasic::logging
 {
+/**
+ * A logging service that uses the spdlog library for logging.
+ *
+ * This service provides a way to create logging contexts and log messages
+ * with different log levels. It supports multiple sinks, including file and
+ * console sinks.
+ */
 class spdlog_service : public yasic::service::service<logging_service>
 {
 public:
-	explicit spdlog_service(std::string const& context);
+	/**
+	 * Initializes the logging service with standard output and a file sink.
+	 *
+	 * @param log_file_name Name of the log file to write to.
+	 */
+	explicit spdlog_service(std::string_view log_file_name);
 
-	void set_level(log_level log_level) override;
+	/**
+	 * Set the minimum log level for a specific context.
+	 *
+	 * @param ctx Context for which to set the log level.
+	 * @param log_level Level to set for the context.
+	 */
+	void set_level(context const& ctx, log_level log_level) override;
+
+	/**
+	 * Create a new logging context with the specified name.
+	 *
+	 * In order to log messages, you must first create a context.
+	 *
+	 * @param name Name of the context to create.
+	 * @return A new logging context.
+	 */
+	context create_context(std::string const& name) override;
+
+	/**
+	 * Add a sink to the logging service.
+	 *
+	 * @param ctx Context to which the sink will be added.
+	 * @param sink Sink to add to the logging service.
+	 */
+	void add_sink(context const& ctx, spdlog::sink_ptr const& sink) const;
 
 private:
-	void log_impl(log_level level, std::string const& message) override;
+	void log_impl(context const&     ctx,
+	              log_level          level,
+	              std::string const& message) override;
 
-	std::shared_ptr<spdlog::logger> m_logger;
+	struct string_hasher final
+	{
+		using is_transparent = void;
+
+		std::size_t operator()(std::string_view const s) const
+		{
+			constexpr std::hash<std::string_view> hasher{};
+			return hasher(s);
+		}
+	};
+
+	std::unordered_map<std::string,
+	                   std::shared_ptr<spdlog::logger>,
+	                   string_hasher,
+	                   std::equal_to<>>
+	    m_logger_registry;
+
+	std::vector<spdlog::sink_ptr> m_shared_sinks;
 };
 } // namespace yasic::logging

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -19,6 +19,8 @@
   #include "spdlog/sinks/stdout_color_sinks.h"
 #endif
 
+#include <vector>
+
 namespace yasic::logging
 {
 spdlog_service::spdlog_service(std::string const& context)

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -85,23 +85,16 @@ void spdlog_service::add_sink(context const&          ctx,
 	}
 }
 
-logging_service::context spdlog_service::create_context(std::string const& name)
+logging_service::context
+spdlog_service::create_context(std::string_view const name)
 {
 	if (!m_logger_registry.contains(name))
 	{
-		auto const [entry, result] = m_logger_registry.try_emplace(
-		    name,
-		    std::make_shared<spdlog::logger>(name));
-
-		if (result)
-		{
-			auto const& logger = entry->second;
-
-			auto& sinks = logger->sinks();
-			sinks.insert(std::end(sinks),
-			             std::begin(m_shared_sinks),
-			             std::end(m_shared_sinks));
-		}
+		m_logger_registry.try_emplace(
+		    std::string{name},
+		    std::make_shared<spdlog::logger>(std::string{name},
+		                                     std::begin(m_shared_sinks),
+		                                     std::end(m_shared_sinks)));
 	}
 	return context{name};
 }

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <string_view>
 
 namespace yasic::logging
 {

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -44,12 +44,13 @@ void spdlog_service::log_impl(log_level const level, std::string const& message)
 	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
 	switch (level)
 	{
-	case log_level::trace: m_logger->trace(message); break;
-	case log_level::debug: m_logger->debug(message); break;
-	case log_level::info: m_logger->info(message); break;
-	case log_level::warn: m_logger->warn(message); break;
-	case log_level::error: m_logger->error(message); break;
-	case log_level::fatal: m_logger->critical(message); break;
+		using enum log_level;
+	case trace: m_logger->trace(message); break;
+	case debug: m_logger->debug(message); break;
+	case info: m_logger->info(message); break;
+	case warn: m_logger->warn(message); break;
+	case error: m_logger->error(message); break;
+	case fatal: m_logger->critical(message); break;
 	}
 }
 
@@ -58,12 +59,13 @@ void spdlog_service::set_level(log_level const log_level)
 	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
 	switch (log_level)
 	{
-	case log_level::trace: m_logger->set_level(spdlog::level::trace); break;
-	case log_level::debug: m_logger->set_level(spdlog::level::debug); break;
-	case log_level::info: m_logger->set_level(spdlog::level::info); break;
-	case log_level::warn: m_logger->set_level(spdlog::level::warn); break;
-	case log_level::error: m_logger->set_level(spdlog::level::err); break;
-	case log_level::fatal: m_logger->set_level(spdlog::level::critical); break;
+		using enum log_level;
+	case trace: m_logger->set_level(spdlog::level::trace); break;
+	case debug: m_logger->set_level(spdlog::level::debug); break;
+	case info: m_logger->set_level(spdlog::level::info); break;
+	case warn: m_logger->set_level(spdlog::level::warn); break;
+	case error: m_logger->set_level(spdlog::level::err); break;
+	case fatal: m_logger->set_level(spdlog::level::critical); break;
 	}
 }
 } // namespace yasic::logging

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -5,13 +5,9 @@
 
 #include "yasic/logging/log_service.h"
 
-#include <memory>
-#include <string>
-
 #include "spdlog/common.h"
 #include "spdlog/logger.h"
 #include "spdlog/sinks/basic_file_sink.h"
-
 #ifdef WIN32
   #include "spdlog/sinks/msvc_sink.h"
   #include "spdlog/sinks/wincolor_sink.h"
@@ -19,53 +15,85 @@
   #include "spdlog/sinks/stdout_color_sinks.h"
 #endif
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace yasic::logging
 {
-spdlog_service::spdlog_service(std::string const& context)
-{
-	std::vector<spdlog::sink_ptr> const sinks{
-	    std::make_shared<spdlog::sinks::basic_file_sink_mt>(context + ".log"),
+spdlog_service::spdlog_service(std::string_view const log_file_name)
+    : m_shared_sinks{
+          std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+              log_file_name.data(),
+              true),
 #ifdef WIN32
-	    std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>(),
-	    std::make_shared<spdlog::sinks::msvc_sink_mt>(),
+          std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>(),
+          std::make_shared<spdlog::sinks::msvc_sink_mt>(),
 #else
-	    std::make_shared<spdlog::sinks::stdout_color_sink_mt>(),
+          std::make_shared<spdlog::sinks::stdout_color_sink_mt>()
 #endif
-	};
+      }
+{}
 
-	m_logger =
-	    std::make_shared<spdlog::logger>(context, sinks.begin(), sinks.end());
-}
-
-void spdlog_service::log_impl(log_level const level, std::string const& message)
+void spdlog_service::log_impl(context const&     ctx,
+                              log_level const    level,
+                              std::string const& message)
 {
-	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
-	switch (level)
+	if (auto const logger = m_logger_registry.find(ctx.name());
+	    logger != m_logger_registry.end())
 	{
-		using enum log_level;
-	case trace: m_logger->trace(message); break;
-	case debug: m_logger->debug(message); break;
-	case info: m_logger->info(message); break;
-	case warn: m_logger->warn(message); break;
-	case error: m_logger->error(message); break;
-	case fatal: m_logger->critical(message); break;
+		// NOLINTNEXTLINE(clang-diagnostic-switch-default)
+		switch (level)
+		{
+			using enum log_level;
+		case trace: logger->second->trace(message); break;
+		case debug: logger->second->debug(message); break;
+		case info: logger->second->info(message); break;
+		case warn: logger->second->warn(message); break;
+		case error: logger->second->error(message); break;
+		case fatal: logger->second->critical(message); break;
+		}
 	}
 }
 
-void spdlog_service::set_level(log_level const log_level)
+void spdlog_service::set_level(context const& ctx, log_level const log_level)
 {
-	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
-	switch (log_level)
+	if (auto const logger = m_logger_registry.find(ctx.name());
+	    logger != m_logger_registry.end())
 	{
-		using enum log_level;
-	case trace: m_logger->set_level(spdlog::level::trace); break;
-	case debug: m_logger->set_level(spdlog::level::debug); break;
-	case info: m_logger->set_level(spdlog::level::info); break;
-	case warn: m_logger->set_level(spdlog::level::warn); break;
-	case error: m_logger->set_level(spdlog::level::err); break;
-	case fatal: m_logger->set_level(spdlog::level::critical); break;
+		// NOLINTNEXTLINE(clang-diagnostic-switch-default)
+		switch (log_level)
+		{
+			using enum log_level;
+		case trace: logger->second->set_level(spdlog::level::trace); break;
+		case debug: logger->second->set_level(spdlog::level::debug); break;
+		case info: logger->second->set_level(spdlog::level::info); break;
+		case warn: logger->second->set_level(spdlog::level::warn); break;
+		case error: logger->second->set_level(spdlog::level::err); break;
+		case fatal: logger->second->set_level(spdlog::level::critical); break;
+		}
 	}
+}
+
+void spdlog_service::add_sink(context const&          ctx,
+                              spdlog::sink_ptr const& sink) const
+{
+	if (auto const logger = m_logger_registry.find(ctx.name());
+	    logger != m_logger_registry.end())
+	{
+		logger->second->sinks().emplace_back(sink);
+	}
+}
+
+logging_service::context spdlog_service::create_context(std::string const& name)
+{
+	if (!m_logger_registry.contains(name))
+	{
+		m_logger_registry
+		    .try_emplace(name, std::make_shared<spdlog::logger>(name))
+		    .first->second->sinks()
+		    .append_range(m_shared_sinks);
+	}
+	return context{name};
 }
 } // namespace yasic::logging

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -1,0 +1,73 @@
+// Copyright 2025 - David Brown <d.brown@bigdavedev.com>
+// SPDX-License-Identifier: MIT
+
+#include "yasic/logging/spdlog_service.h"
+#include "yasic/logging/log_service.h"
+
+#include "spdlog/logger.h"
+#include "spdlog/common.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+#include <string>
+#include <memory>
+
+namespace yasic::logging
+{
+
+spdlog_service::spdlog_service(std::string const& context)
+	: m_logger{std::make_shared<spdlog::logger>(
+	      context, std::make_shared<spdlog::sinks::stdout_color_sink_mt>())}
+{}
+
+void spdlog_service::log_impl(log_level const level, std::string const& message)
+{
+	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
+	switch (level)
+	{
+	case log_level::trace:
+		m_logger->trace(message);
+		break;
+	case log_level::debug:
+		m_logger->debug(message);
+		break;
+	case log_level::info:
+		m_logger->info(message);
+		break;
+	case log_level::warn:
+		m_logger->warn(message);
+		break;
+	case log_level::error:
+		m_logger->error(message);
+		break;
+	case log_level::fatal:
+		m_logger->critical(message);
+		break;
+	}
+}
+
+void spdlog_service::set_level(log_level const log_level)
+{
+	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
+	switch (log_level)
+	{
+	case log_level::trace:
+		m_logger->set_level(spdlog::level::trace);
+		break;
+	case log_level::debug:
+		m_logger->set_level(spdlog::level::debug);
+		break;
+	case log_level::info:
+		m_logger->set_level(spdlog::level::info);
+		break;
+	case log_level::warn:
+		m_logger->set_level(spdlog::level::warn);
+		break;
+	case log_level::error:
+		m_logger->set_level(spdlog::level::err);
+		break;
+	case log_level::fatal:
+		m_logger->set_level(spdlog::level::critical);
+		break;
+	}
+}
+} // namespace yasic::logging

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -11,8 +11,13 @@
 #include "spdlog/common.h"
 #include "spdlog/logger.h"
 #include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/sinks/msvc_sink.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
+
+#ifdef WIN32
+  #include "spdlog/sinks/msvc_sink.h"
+  #include "spdlog/sinks/wincolor_sink.h"
+#else
+  #include "spdlog/sinks/stdout_color_sinks.h"
+#endif
 
 namespace yasic::logging
 {
@@ -21,7 +26,7 @@ spdlog_service::spdlog_service(std::string const& context)
 	std::vector<spdlog::sink_ptr> const sinks{
 	    std::make_shared<spdlog::sinks::basic_file_sink_mt>(context + ".log"),
 #ifdef WIN32
-		std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>(),
+	    std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>(),
 	    std::make_shared<spdlog::sinks::msvc_sink_mt>(),
 #else
 	    std::make_shared<spdlog::sinks::stdout_color_sink_mt>(),

--- a/yasic/logging/source/yasic/logging/spdlog_service.cpp
+++ b/yasic/logging/source/yasic/logging/spdlog_service.cpp
@@ -2,46 +2,47 @@
 // SPDX-License-Identifier: MIT
 
 #include "yasic/logging/spdlog_service.h"
+
 #include "yasic/logging/log_service.h"
 
-#include "spdlog/logger.h"
-#include "spdlog/common.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
-
-#include <string>
 #include <memory>
+#include <string>
+
+#include "spdlog/common.h"
+#include "spdlog/logger.h"
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/msvc_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 
 namespace yasic::logging
 {
-
 spdlog_service::spdlog_service(std::string const& context)
-	: m_logger{std::make_shared<spdlog::logger>(
-	      context, std::make_shared<spdlog::sinks::stdout_color_sink_mt>())}
-{}
+{
+	std::vector<spdlog::sink_ptr> const sinks{
+	    std::make_shared<spdlog::sinks::basic_file_sink_mt>(context + ".log"),
+#ifdef WIN32
+		std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>(),
+	    std::make_shared<spdlog::sinks::msvc_sink_mt>(),
+#else
+	    std::make_shared<spdlog::sinks::stdout_color_sink_mt>(),
+#endif
+	};
+
+	m_logger =
+	    std::make_shared<spdlog::logger>(context, sinks.begin(), sinks.end());
+}
 
 void spdlog_service::log_impl(log_level const level, std::string const& message)
 {
 	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
 	switch (level)
 	{
-	case log_level::trace:
-		m_logger->trace(message);
-		break;
-	case log_level::debug:
-		m_logger->debug(message);
-		break;
-	case log_level::info:
-		m_logger->info(message);
-		break;
-	case log_level::warn:
-		m_logger->warn(message);
-		break;
-	case log_level::error:
-		m_logger->error(message);
-		break;
-	case log_level::fatal:
-		m_logger->critical(message);
-		break;
+	case log_level::trace: m_logger->trace(message); break;
+	case log_level::debug: m_logger->debug(message); break;
+	case log_level::info: m_logger->info(message); break;
+	case log_level::warn: m_logger->warn(message); break;
+	case log_level::error: m_logger->error(message); break;
+	case log_level::fatal: m_logger->critical(message); break;
 	}
 }
 
@@ -50,24 +51,12 @@ void spdlog_service::set_level(log_level const log_level)
 	// NOLINTNEXTLINE(clang-diagnostic-switch-default)
 	switch (log_level)
 	{
-	case log_level::trace:
-		m_logger->set_level(spdlog::level::trace);
-		break;
-	case log_level::debug:
-		m_logger->set_level(spdlog::level::debug);
-		break;
-	case log_level::info:
-		m_logger->set_level(spdlog::level::info);
-		break;
-	case log_level::warn:
-		m_logger->set_level(spdlog::level::warn);
-		break;
-	case log_level::error:
-		m_logger->set_level(spdlog::level::err);
-		break;
-	case log_level::fatal:
-		m_logger->set_level(spdlog::level::critical);
-		break;
+	case log_level::trace: m_logger->set_level(spdlog::level::trace); break;
+	case log_level::debug: m_logger->set_level(spdlog::level::debug); break;
+	case log_level::info: m_logger->set_level(spdlog::level::info); break;
+	case log_level::warn: m_logger->set_level(spdlog::level::warn); break;
+	case log_level::error: m_logger->set_level(spdlog::level::err); break;
+	case log_level::fatal: m_logger->set_level(spdlog::level::critical); break;
 	}
 }
 } // namespace yasic::logging

--- a/yasic/main.cpp
+++ b/yasic/main.cpp
@@ -18,11 +18,16 @@ int main(int argc, char* argv[])
 	auto service_locator = yasic::service::service_locator{};
 
 	service_locator.register_service(
-	    std::make_shared<yasic::logging::spdlog_service>("Yasic"));
+	    std::make_shared<yasic::logging::spdlog_service>("Yasic.log"));
+	auto const logging_service =
+	    service_locator.get_service<yasic::logging::logging_service>();
+
+	auto const main_log_context = logging_service->create_context("main");
 
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_AUDIO))
 	{
 		service_locator.get_service<yasic::logging::logging_service>()->log(
+		    main_log_context,
 		    yasic::logging::log_level::fatal,
 		    "Failed to initialize SDL: {}",
 		    SDL_GetError());

--- a/yasic/main.cpp
+++ b/yasic/main.cpp
@@ -1,14 +1,33 @@
 // Copyright 2025 - David Brown <d.brown@bigdavedev.com>
 // SPDX-License-Identifier: MIT
+#include "yasic/logging/log_service.h"
+#include "yasic/logging/spdlog_service.h"
+#include "yasic/service/service_locator.h"
+
+#include "SDL3/SDL_error.h"
 #include "SDL3/SDL_init.h"
 #include "SDL3/SDL_main.h"
+
+#include <memory>
 
 int main(int argc, char* argv[])
 {
 	static_cast<void>(argc);
 	static_cast<void>(argv);
 
-	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_AUDIO);
+	auto service_locator = yasic::service::service_locator{};
+
+	service_locator.register_service(
+	    std::make_shared<yasic::logging::spdlog_service>("Yasic"));
+
+	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_AUDIO))
+	{
+		service_locator.get_service<yasic::logging::logging_service>()->log(
+		    yasic::logging::log_level::fatal,
+		    "Failed to initialize SDL: {}",
+		    SDL_GetError());
+		return -1;
+	}
 
 	SDL_Quit();
 

--- a/yasic/service/include/yasic/service/service.h
+++ b/yasic/service/include/yasic/service/service.h
@@ -16,8 +16,16 @@ class service_base
 public:
 	virtual ~service_base() = default;
 
+	service_base() = default;
+
+	service_base(service_base const&) = delete;
+	service_base& operator=(service_base const&) = delete;
+
+	service_base(service_base&&) = default;
+	service_base& operator=(service_base&&) = default;
+
 private:
-	virtual std::type_index type() const = 0;
+	[[nodiscard]] virtual std::type_index type() const = 0;
 };
 
 /**
@@ -29,7 +37,7 @@ template <typename T>
 class service : public T
 {
 	friend class service_locator;
-	std::type_index type() const override
+	[[nodiscard]] std::type_index type() const override
 	{
 		return std::type_index{typeid(T)};
 	}

--- a/yasic/service/include/yasic/service/service_locator.h
+++ b/yasic/service/include/yasic/service/service_locator.h
@@ -36,7 +36,7 @@ public:
 		static_assert(std::is_base_of_v<service_base, T>,
 		              "T must derive from service_base");
 
-		std::lock_guard<std::mutex> const lock{m_mutex};
+		std::scoped_lock const lock{m_mutex};
 
 		if (m_services.contains(service->type()))
 		{
@@ -54,7 +54,7 @@ public:
 	template <typename T>
 	void unregister_service()
 	{
-		std::lock_guard<std::mutex> const lock{m_mutex};
+		std::scoped_lock const lock{m_mutex};
 
 		if (auto const type_index = std::type_index{typeid(T)};
 		    m_services.contains(type_index))
@@ -72,7 +72,7 @@ public:
 	template <typename T>
 	std::shared_ptr<T> get_service() const
 	{
-		std::lock_guard<std::mutex> const lock{m_mutex};
+		std::scoped_lock const lock{m_mutex};
 
 		if (auto const entry = m_services.find(std::type_index{typeid(T)});
 		    entry != m_services.end())

--- a/yasic/service/include/yasic/service/service_locator.h
+++ b/yasic/service/include/yasic/service/service_locator.h
@@ -36,7 +36,7 @@ public:
 		static_assert(std::is_base_of_v<service_base, T>,
 		              "T must derive from service_base");
 
-		std::lock_guard lock{m_mutex};
+		std::lock_guard<std::mutex> const lock{m_mutex};
 
 		if (m_services.contains(service->type()))
 		{
@@ -54,7 +54,7 @@ public:
 	template <typename T>
 	void unregister_service()
 	{
-		std::lock_guard lock{m_mutex};
+		std::lock_guard<std::mutex> const lock{m_mutex};
 
 		if (auto const type_index = std::type_index{typeid(T)};
 		    m_services.contains(type_index))
@@ -72,12 +72,12 @@ public:
 	template <typename T>
 	std::shared_ptr<T> get_service() const
 	{
-		std::lock_guard lock{m_mutex};
+		std::lock_guard<std::mutex> const lock{m_mutex};
 
-		if (auto const it = m_services.find(std::type_index{typeid(T)});
-		    it != m_services.end())
+		if (auto const entry = m_services.find(std::type_index{typeid(T)});
+		    entry != m_services.end())
 		{
-			return std::static_pointer_cast<T>(it->second);
+			return std::static_pointer_cast<T>(entry->second);
 		}
 		return nullptr;
 	}

--- a/yasic/service/include/yasic/service/service_locator.h
+++ b/yasic/service/include/yasic/service/service_locator.h
@@ -36,7 +36,7 @@ public:
 		static_assert(std::is_base_of_v<service_base, T>,
 		              "T must derive from service_base");
 
-		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
+		// NOLINTNEXTLINE(*ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (m_services.contains(service->type()))
@@ -55,7 +55,7 @@ public:
 	template <typename T>
 	void unregister_service()
 	{
-		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
+		// NOLINTNEXTLINE(*ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (auto const type_index = std::type_index{typeid(T)};
@@ -74,7 +74,7 @@ public:
 	template <typename T>
 	std::shared_ptr<T> get_service() const
 	{
-		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
+		// NOLINTNEXTLINE(*ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (auto const entry = m_services.find(std::type_index{typeid(T)});

--- a/yasic/service/include/yasic/service/service_locator.h
+++ b/yasic/service/include/yasic/service/service_locator.h
@@ -36,6 +36,7 @@ public:
 		static_assert(std::is_base_of_v<service_base, T>,
 		              "T must derive from service_base");
 
+		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (m_services.contains(service->type()))
@@ -54,6 +55,7 @@ public:
 	template <typename T>
 	void unregister_service()
 	{
+		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (auto const type_index = std::type_index{typeid(T)};
@@ -72,6 +74,7 @@ public:
 	template <typename T>
 	std::shared_ptr<T> get_service() const
 	{
+		// NOLINTNEXTLINE(clang-diagnostic-ctad-maybe-unsupported)
 		std::scoped_lock const lock{m_mutex};
 
 		if (auto const entry = m_services.find(std::type_index{typeid(T)});


### PR DESCRIPTION
This PR introduces two logging services.

1. `spglog_service`
2. `null_log_service`

By default, `spdlog_service` is used in applications whereas `null_log_service` is intended to be used in unit testing where logging is less important and introduces unstable dependencies on things like filesystems.